### PR TITLE
Fetch fonts over HTTPS to avoid "mixed content" warning

### DIFF
--- a/grails-app/views/finder/index.gsp
+++ b/grails-app/views/finder/index.gsp
@@ -21,7 +21,7 @@
     <script type="text/javascript" src="${resource(dir: 'js', file: 'stepcarousel.js')}"></script>
 
     <link rel="shortcut icon" href="${resource(dir: 'images', file: 'favicon.ico')}" type="image/x-icon"/>
-    <link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>
 
     <g:render template="auv_functions_js"></g:render>
     <g:render template="finder_js"></g:render>


### PR DESCRIPTION
Previously, the following error was occurring:

Mixed Content: The page at 'https://auv.aodn.org.au/auv/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Lobster'. This request has been blocked; the content must be served over HTTPS.