### PR TITLE
Removed fake GFI requests. Runs from geoserver data only

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -39,14 +39,14 @@ grails.spring.bean.packages = []
 // set per-environment serverURL stem for creating absolute links
 environments {
     production {
-        grails.serverURL = "http://auv.aodn.org.au/${appName}"
+        grails.serverURL = "https://auv.aodn.org.au/${appName}"
     }
     development {
         grails.serverURL = "http://localhost:8080/${appName}"
 
         geoserver {
             context = 'geoserver'
-            url = "http://geoserver-123.aodn.org.au/geoserver"
+            url = "https://geoserver-123.aodn.org.au/geoserver"
             namespace = 'imos'
             layerNames {
                 tracks = 'auv_tracks_vw'
@@ -55,16 +55,12 @@ environments {
         }
 
         baseLayer {
-            url = 'http://geoserver-static.aodn.org.au/geoserver/baselayers/wms'
+            url = 'https://geoserver-static.aodn.org.au/geoserver/baselayers/wms'
             name = 'default_basemap_simple'
         }
 
-        imageFileServer {
-            url = 'http://data.aodn.org.au/IMOS/public/AUV/'
-        }
-
         mest {
-            url = 'http://imosmest.aodn.org.au/geonetwork'
+            url = 'https://catalogue-imos.aodn.org.au/geonetwork'
         }
     }
     test {

--- a/grails-app/controllers/auv/ProxyController.groovy
+++ b/grails-app/controllers/auv/ProxyController.groovy
@@ -1,9 +1,3 @@
-//*************************************************//
-//  Copyright 2010 IMOS
-//  The IMOS AUV Viewer is distributed under
-//  the terms of the GNU General Public License
-//*************************************************//
-
 
 package auv
 
@@ -20,7 +14,7 @@ class ProxyController {
             ]
 
             def format
-            def thetext = params.url.toURL()
+            def thetext = params.url.replaceAll(/\'/,'%27').toURL()
 
             // get the domain name from the supplied uri
             def hostName = params.url.toURL().getHost()
@@ -33,10 +27,12 @@ class ProxyController {
                 } else {
                     format = "text/html"
                 }
-                render(text: thetext.text, contentType: format, encoding: "UTF-8")
+
+                def returnText = thetext.text
+                render(text: returnText, contentType: format, encoding: "UTF-8")
             }
             else {
-                log.error("Proxy: The url " + thetext.text + "was not allowed")
+                log.info("Proxy: The url " + params.url + "was not allowed")
                 render(text: "Host not allowed", contentType: "text/html", encoding: "UTF-8")
             }
         }

--- a/grails-app/views/finder/_finder_js.gsp
+++ b/grails-app/views/finder/_finder_js.gsp
@@ -1,11 +1,11 @@
 <script>
 
-    // *****  TODO get the bounds from geoserver
+    // *****  TODO get the mapBounds from geoserver
     var buff = 10;
-    var bounds = "" + (112.947 - buff) + "," + (-33.00 - buff) + "," + (116.46 + buff) + "," + (0.874 + buff);
+    var mapBounds = "" + (112.947 - buff) + "," + (-33.00 - buff) + "," + (116.46 + buff) + "," + (0.874 + buff);
 
-    var mapheight = '320';
-    var mapwidth = '400';
+    var mapheight = '280';
+    var mapwidth = '360';
     var size = new OpenLayers.Size(30, 24);
     var offset = new OpenLayers.Pixel(-(size.w / 2) + 5, -(size.h - 1));
     var icon = new OpenLayers.Icon('images/auv-marker.png', size, offset);
@@ -50,20 +50,9 @@
             jQuery(this).removeClass('hover');
         });
 
-
-        // when user selects track from dropdown
-        jQuery('#trackSelector').change(function () {
-            if (jQuery(this).val() != "default") {
-                resetStyleSelect(); // reset the style selector to default
-                allTracksSelector("#" + jQuery(this).val());
-            }
-        });
-
+        // clicking on tracks loaded from sites on map
         jQuery('.getfeatureTitle').live('click', function () {
-            hideAllTrackHTML();
-            var site_code = jQuery(this).siblings('.getfeatureCode').text();
-            var extent = jQuery(this).siblings('.getfeatureExtent').text();
-            showSiteCode(site_code, extent);
+            selectSiteCode(jQuery(this).siblings('.getfeatureCode').text());
         });
 
         // slider to change images
@@ -80,22 +69,18 @@
         });
 
         resetStyleSelect(); // reset the style selector to default
-
         mapinit();
 
         <g:if test="${flash.zoom}" >
         map.setCenter(new OpenLayers.LonLat(${flash.lon}, ${flash.lat}), 16);
         </g:if>
 
-
-        // populate the track dropdown select and create hidden track info
+        // populate the track dropdown select
         populateTracks();
 
         // then set layout with the map initialised
         jQuery('#mainbody').layout({
-            //applyDefaultStyles: true,
             west: {
-                //applyDefaultStyles: true,
                 minSize: 410
             }
         });
@@ -107,8 +92,8 @@
             }
         });
 
-        // hide the gallery. needs to exist for step carousel
-        jQuery('#mygallery, #stepcarouselcontrols').toggle(false);
+        // hide the gallery
+        toggleGalleryItems(false);
 
         // hide the cover over the ugly load
         jQuery('#loading_cover').fadeOut(1000);

--- a/grails-app/views/finder/index.gsp
+++ b/grails-app/views/finder/index.gsp
@@ -89,7 +89,7 @@
         <div class="title">
             <h1>Autonomous Underwater Vehicle</h1>
 
-            <h3>Images Viewer</h3>
+            <h2>Images Viewer</h2>
         </div>
 
     </div>
@@ -147,58 +147,59 @@
     </div>
 
 
-    <div id="imagecontainer" class="ui-layout-center">
+    <div  class="ui-layout-center">
+        <div id="imagecontainer" >
 
-        <div id="helpSection">
-            <h3>How to use this AUV image viewer</h3>
+            <div id="helpSection">
+                <h1>How to use this AUV image viewer</h1>
 
-            <ol>
-                <li>Click on a AUV Icon, or choose from the track list.
-                <li>Choose a track and the map will zoom to it.
-                <li>Click on a track to view the closest images to the click origin.
-            </ol>
-        </div>
+                <ol>
+                    <li>Click on a AUV Icon, or choose from the track list.
+                    <li>Choose a track and the map will zoom to it.
+                    <li>Click on a track to view the closest images and meta information about the site closest to the click origin.
+                </ol>
+            </div>
 
-        <div id="mygallery" class="stepcarousel">
+            <div id="mygallery" class="stepcarousel">
 
-            <div class="belt">
-                <div class="panel">
-                    <img src="images/mapshadow.png"/>
+                <div class="belt">
+                    <div class="panel">
+                        <img src="images/mapshadow.png"/>
+                    </div>
                 </div>
             </div>
-        </div>
 
-        <div id="galleryControls" style="height:360px">
-            <div id="trackSelectorDiv" class="ui-layout-north buttons">
-                <select name="trackSelector" id="trackSelector">
-                    <option id="default" value="default">... Choose a AUV Track...</option>
-                </select>
-                <button onclick="resetMap()" id="resetmap">RESET MAP</button>
+            <div id="galleryControls" style="height:360px">
+                <div id="trackSelectorDiv" class="ui-layout-north buttons">
+                    <select name="trackSelector" id="trackSelector" onChange="allTracksSelector(this.options[this.selectedIndex].value)" >
+                        <option id="default" value="default">... Choose a AUV Track...</option>
+                    </select>
+                    <button onclick="resetMap()" id="resetmap">RESET</button>
 
-                <div id="loader">Loading...
-                    <img alt="loading..." src="images/loading.gif">
-                </div>
-
-                <h3 id="thisTrackInfo">&nbsp;</h3>
-
-            </div>
-
-            <div id="trackcontainer" class="ui-layout-west">
-
-                <div id="track_html"></div>
-            </div>
-
-            <div class="ui-layout-center">
-                <div id="stepcarouselcontrols">
-                    <p id="unsorted_status">
-                        <b>Current Viewing Images:</b> <span id="statusA"></span> to <span
-                            id="statusB"></span><b>of:</b> <span id="statusC"></span> <b>near your click point</b>
-                    </p>
-
-                    <div id="sliderContainer">
-                        <div id="slider"></div>
+                    <div id="loader">Loading...
+                        <img alt="loading..." src="images/loading.gif">
                     </div>
 
+                    <h3 id="trackInfoHeader">&nbsp;</h3>
+
+                </div>
+
+                <div id="trackInfoContainer" class="ui-layout-west">
+                    <div id="trackInfo"></div>
+                </div>
+
+                <div class="ui-layout-center">
+                    <div id="stepcarouselcontrols">
+                        <p id="unsorted_status">
+                            <b>Current Viewing Images:</b> <span id="statusA"></span> to <span
+                                id="statusB"></span><b>of:</b> <span id="statusC"></span> <b>near your click point</b>
+                        </p>
+
+                        <div id="sliderContainer">
+                            <div id="slider"></div>
+                        </div>
+
+                    </div>
                 </div>
             </div>
         </div>

--- a/web-app/css/map.css
+++ b/web-app/css/map.css
@@ -38,23 +38,14 @@ img.logo {
 
 #mainbody {
     height: 100%;
-    overflow: auto !  important;
+    overflow-y: auto !  important;
     padding-bottom: 15px;
-
 }
 
 .auvHeader {
     margin: 0 0 30px 0;
     padding: 20px 10px;
-    background-color: #D4D6D7;
-    background: #d4d6d7;
-    background: -moz-radial-gradient(center, ellipse cover, #d4d6d7 0%, #c4c4c4 100%);
-    background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%,#d4d6d7), color-stop(100%,#c4c4c4));
-    background: -webkit-radial-gradient(center, ellipse cover, #d4d6d7 0%,#c4c4c4 100%);
-    background: -o-radial-gradient(center, ellipse cover, #d4d6d7 0%,#c4c4c4 100%);
-    background: -ms-radial-gradient(center, ellipse cover, #d4d6d7 0%,#c4c4c4 100%);
-    background: radial-gradient(ellipse at center, #d4d6d7 0%,#c4c4c4 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d4d6d7', endColorstr='#c4c4c4',GradientType=1 );
+    background-color: #C9CBCC;
 }
 
 div#logo,
@@ -64,14 +55,18 @@ div.title * {
 }
 
 div.title {
-    font-family: "Oswald",sans-serif;
     left: 460px;
     position: absolute;
     top: 40px;
-    font-size: 20px;
 }
+
+h1, h2, h3, h4 {
+    font-family: "Oswald",sans-serif;
+}
+
 div.title h1 {
     font-size: 32px;
+    font-family: "Oswald",sans-serif;
     color: #607178;
 }
 
@@ -105,15 +100,20 @@ div.title h1 {
 
 }
 
-#trackcontainer {
+#trackInfoContainer {
     padding-right: 5px;
-    padding: 5px;
-    margin: 5px;
+    margin-right: 5px;
 }
 
-#track_html {
-    overflow: auto;
-    height: 250px;
+#trackInfo {
+    margin: 25px 0 ;
+}
+
+#trackInfo H3 {
+    display: none;
+}
+#trackInfo .getfeatureTitle {
+    text-transform: capitalize;
 }
 
 #helpSection, #galleryControls {
@@ -150,7 +150,7 @@ div.title h1 {
 }
 
 #mapscale div {
-    padding: 0px;
+    padding: 0;
     font-size: 9px;
 }
 
@@ -168,7 +168,7 @@ div.title h1 {
 }
 
 .nofeature {
-    margin: 2px 0px 5px 0px;
+    margin: 2px 0 5px 0;
     padding: 5px;
     width: 100%;
     background-color: #fafafa;

--- a/web-app/theme/default/style.css
+++ b/web-app/theme/default/style.css
@@ -1,7 +1,5 @@
 div.olMap {
 	z-index: 0;
-    padding: 0px!important;
-    margin: 0px!important;
     cursor: default;
 }
 


### PR DESCRIPTION
This code base is now 6 years old. Go easy, as this app is intended to be replaced in the coming future.
It relies heavily on jQuery to work and is a little loose around the edges.

The main part of the changes is too remove where a WFS query was used to create a series of 'fake' GFI responses. This was done so whenever a site was chosen with the drop down picker or clicking on the map the GFI (meta information and links to data) was shown.
Now the user only sees the meta information after clicking on the map.